### PR TITLE
Change md5sum for changed external resourse

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,3 +29,5 @@ scalacOptions ++= Seq("-unchecked", "-deprecation")
 organization := "Data Intuitive"
 startYear := Some(2020)
 licenses += "GPL-3.0-or-later" -> url("https://www.gnu.org/licenses/gpl-3.0.html")
+
+Test / parallelExecution := false

--- a/src/test/scala/com/dataintuitive/viash/MainBuildDockerSuite.scala
+++ b/src/test/scala/com/dataintuitive/viash/MainBuildDockerSuite.scala
@@ -738,7 +738,7 @@ class MainBuildDockerSuite extends FunSuite with BeforeAndAfterAll {
     val expectedResources = List(
       //("check_bash_version.sh", "0c3c134d4ff0ea3a4a3b32e09fb7c100"),
       ("code.sh", "efa9e1aa1c5f2a0b91f558ead5917c68"),
-      ("NOTICE", "72227b5fda1a673b084aef2f1b580ec3"),
+      ("NOTICE", "d64d250d1c3a5af25977651b5443aedb"),
       ("resource1.txt", "bc9171172c4723589a247f99b838732d"),
       ("resource2.txt", "9cd530447200979dbf9e117915cbcc74"),
       ("resource_folder/resource_L1_1.txt", "51954bf10062451e683121e58d858417"),


### PR DESCRIPTION
The EULA of scala was updated resulting in a different md5sum,
change the hash which the "Check resources are copied from and to the correct location" copy test uses